### PR TITLE
Get record cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Development
 
 - Add command `ckan fisbroker get-record` to cli for testing conversion from CSW to package dict.
+- Add code for extracting an HVD category.
 
 ## [1.5.0](https://github.com/berlinonline/ckanext-fisbroker/releases/tag/1.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add command `ckan fisbroker get-record` to cli for testing conversion from CSW to package dict.
 - Add code for extracting an HVD category.
+- Suppress logging during CLI unit tests to prevent issues with CKAN log messages appearing in stdout (not stderr), causing the tests to fail.
 
 ## [1.5.0](https://github.com/berlinonline/ckanext-fisbroker/releases/tag/1.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ _(2026-02-12)_
 
 - Template changes for styleguide implementation
 
+- Add command `ckan fisbroker get-record` to cli for testing conversion from CSW to package dict.
+
 ## [1.4.10](https://github.com/berlinonline/ckanext-fisbroker/releases/tag/1.4.10)
 
 _(2026-01-12)_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
 ## Development
+
+- Add command `ckan fisbroker get-record` to cli for testing conversion from CSW to package dict.
+
 ## [1.5.0](https://github.com/berlinonline/ckanext-fisbroker/releases/tag/1.5.0)
 
 _(2026-02-12)_
 
 - Template changes for styleguide implementation
-
-- Add command `ckan fisbroker get-record` to cli for testing conversion from CSW to package dict.
 
 ## [1.4.10](https://github.com/berlinonline/ckanext-fisbroker/releases/tag/1.4.10)
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ listing all instances of FisbrokerPlugin ...
 
 ## Copying and License
 
-This material is copyright © 2016 – 2024  [BerlinOnline GmbH](https://berlinonline.net).
+This material is copyright © 2016 – 2026  [BerlinOnline GmbH](https://berlinonline.net).
 
 This extension is open and licensed under the GNU Affero General Public License (AGPL) v3.0.
 Its full text may be found at:

--- a/ckanext/fisbroker/cli.py
+++ b/ckanext/fisbroker/cli.py
@@ -1,26 +1,29 @@
 '''Module to implement a click CLI for the FIS-Broker-Harvester'''
 
+import datetime
 import json
 import logging
 import sys
 import time
-import datetime
+from pydoc import doc
 
-import click
-
-from ckan import logic
-from ckan import model
-from ckan.lib import mailer
+import ckan.plugins as plugins
 import ckan.plugins.toolkit as tk
+import click
+from ckan import logic, model
+from ckan.lib import mailer
+from ckan.lib.navl.dictization_functions import Missing, validate
+from ckantoolkit import config
 
-from ckanext.fisbroker import HARVESTER_ID
 import ckanext.fisbroker.blueprint as blueprint
-from ckanext.fisbroker.fisbroker_harvester import FisbrokerHarvester
+from ckanext.fisbroker import HARVESTER_ID
+from ckanext.fisbroker.csw_client import CswService
 from ckanext.fisbroker.exceptions import NotFoundInFisbrokerError
-
-from ckanext.harvest.model import HarvestObject, HarvestSource, HarvestJob
+from ckanext.fisbroker.fisbroker_harvester import FisbrokerHarvester
+from ckanext.harvest.model import HarvestJob, HarvestObject, HarvestSource
 from ckanext.harvest.queue import get_connection
-
+from ckanext.spatial.harvested_metadata import ISODocument
+from ckanext.spatial.harvesters.csw import CSWHarvester
 
 LOG = logging.getLogger(__name__)
 FISBROKER_SOURCE_NAME = 'harvest-fisbroker'
@@ -38,7 +41,7 @@ def _filter_datasets(datasets):
     '''Generate a list of filtered datasets.'''
     return [_filter_dataset(dataset) for dataset in datasets]
 
-def _list_sources():
+def _list_sources() -> list:
     '''List all instances of the FIS-Broker harvester.
     '''
     context = {'model': model, 'session': model.Session}
@@ -421,5 +424,98 @@ def check_hanging_jobs():
     except Exception as e:
         alerts.append(f"Monitoring failed: {str(e)}")
 
+XML = 'xml'
+ISO = 'iso'
+PACKAGE_BASE = 'package_base'
+PACKAGE = 'package'
+RECORD_FORMATS = [ XML, ISO, PACKAGE_BASE, PACKAGE ]
+DEFAULT_RECORD_FORMAT = PACKAGE
+@fisbroker.command()
+@click.option("-s",  "--source", help="The source id of the harvester. Default is the first one we find.")
+@click.option("-r",  "--record", help="The id of the record to get", required=True)
+@click.option("-f",  "--format", help=f"output format, one of [{'|'.join(RECORD_FORMATS)}]", default=PACKAGE)
+def get_record(source: str, record: str, format: str):
+    """
+        Get the document for `record` from `source`.
+    """
+    sources = _list_sources()
+    if source:
+        source_lookup = { source['id']: source for source in sources }
+        source_obj = source_lookup[source]
+    else:
+        source_obj = sources[0]
+    endpoint = source_obj['url']
+    click.echo(f"getting {record} from {endpoint}", err=True)
+    csw = CswService(endpoint=endpoint)
+    document = csw.getrecordbyid([record])
+    iso_document = ISODocument(xml_tree=document['tree'])
+    iso_values = iso_document.read_values()
+    if format == XML:
+        click.echo(document['xml'])
+    elif format == ISO:
+        click.echo(json.dumps(iso_values, indent=JSON_INDENT))
+    else:
+        # get_package_dict() is coupled to CKAN's harvesting infrastructure
+        from unittest.mock import Mock, patch
+
+        harvest_object = Mock()
+        harvest_object.source.id = "source-id"
+
+        harvester = CSWHarvester()
+        with patch("ckan.model.Package.get") as mock_get:
+            mock_dataset = Mock()
+            mock_dataset.owner_org = "test-org-id"
+            mock_get.return_value = mock_dataset
+
+            # optionally patch error logging too
+            with patch.object(harvester, "_save_object_error", lambda *a, **k: None):
+                package_dict = harvester.get_package_dict(iso_values, harvest_object)
+                if format == PACKAGE_BASE:
+                    click.echo(json.dumps(package_dict, indent=JSON_INDENT))
+                else:
+                    harvester = FisbrokerHarvester()
+                    package_dict = harvester.get_package_dict(None, {
+                        'package_dict': package_dict,
+                        'iso_values': iso_values,
+                        'harvest_object': harvest_object,
+                        'xml_tree': iso_document.xml_tree
+                    })
+                    context = {
+                        "model": model,
+                        "session": model.Session,
+                        "user": "test-user",
+                    }
+                    schema_plugin = plugins.get_plugin(config['ckanext.geoharvester.datasetschema'])
+                    click.echo(schema_plugin, err=True)
+                    schema = schema_plugin.show_package_schema()
+                    result, errors = validate(package_dict, schema, context)
+                    cleaned = clean_missing(result)
+                    # click.echo(cleaned)
+                    click.echo(json.dumps(cleaned, indent=JSON_INDENT))
+
+def clean_missing(data):
+    if isinstance(data, dict):
+        return {
+            k: clean_missing(v)
+            for k, v in data.items()
+            if not isinstance(v, Missing)
+        }
+    elif isinstance(data, list):
+        return [clean_missing(v) for v in data if not isinstance(v, Missing)]
+    else:
+        return data
+
 class MockHarvestJob:
     pass
+
+class DummySource:
+    def __init__(self):
+        self.id = "dummy-source"
+
+class DummyHarvestObject:
+    def __init__(self):
+        self.id = "dummy-id"
+        self.guid = "dummy-guid"
+        self.job = None
+        self.content = None
+        self.source = DummySource()

--- a/ckanext/fisbroker/fisbroker_harvester.py
+++ b/ckanext/fisbroker/fisbroker_harvester.py
@@ -44,6 +44,7 @@ from ckanext.spatial.validation.validation import BaseValidator
 from ckanext.fisbroker import HARVESTER_ID
 from ckanext.fisbroker.csw_client import CswService
 from ckanext.fisbroker.fisbroker_resource_annotator import FISBrokerResourceAnnotator
+from ckanext.fisbroker.hvd_extractor import extract_hvd_categories, HVD_PREFIX
 import ckanext.fisbroker.helper as helpers
 
 
@@ -869,6 +870,7 @@ class FisbrokerHarvester(CSWHarvester):
 
             package_dict = data_dict['package_dict']
             iso_values = data_dict['iso_values']
+            xml_tree = data_dict['xml_tree']
             harvest_object = data_dict.get('harvest_object')
 
             LOG.debug(iso_values['title'])
@@ -1007,6 +1009,13 @@ class FisbrokerHarvester(CSWHarvester):
 
             # LOG.info("----- data after get_package_dict -----")
             # LOG.debug(package_dict)
+
+            # HVD categories
+            hvd_categories = extract_hvd_categories(xml_tree)
+            codes = [category['uri'].removeprefix(HVD_PREFIX) for category in hvd_categories]
+            if len(codes) > 0:
+                # we assume there can be only one HVD category (but is that true?)
+                extras['hvd_category'] = codes[0]
 
             # extras
             package_dict['extras'] = extras_as_list(extras)

--- a/ckanext/fisbroker/fisbroker_harvester.py
+++ b/ckanext/fisbroker/fisbroker_harvester.py
@@ -615,7 +615,7 @@ class FisbrokerHarvester(CSWHarvester):
             self.__base_transform_to_iso_called = False
             content = self.transform_to_iso(original_document, original_format, harvest_object)
             if not self.__base_transform_to_iso_called:
-                LOG.warn("Deprecation warning: calling transform_to_iso directly is deprecated. " +
+                LOG.warning("Deprecation warning: calling transform_to_iso directly is deprecated. " +
                          "Please use the ISpatialHarvester interface method instead.")
 
             for harvester in plugins.PluginImplementations(ISpatialHarvester):

--- a/ckanext/fisbroker/hvd_extractor.py
+++ b/ckanext/fisbroker/hvd_extractor.py
@@ -1,0 +1,88 @@
+'''
+Code for extracting HVD-category information from geospatial metadata (ISO 19139),
+as it is found in the getrecordbyid() responses from a CSW. The pattern is as
+follows:
+
+```xml
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd">
+<!-- HVD Thesaurus-Based Keywords Section -->
+    <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+            <!-- Category Keyword -->
+            <gmd:keyword>
+                <gmx:Anchor xlink:href="http://data.europa.eu/bna/c_dd313021">Earth observation and environment</gmx:Anchor>
+            </gmd:keyword>
+            <!-- Thesaurus Reference -->
+            <gmd:thesaurusName>
+                <gmd:CI_Citation>
+                    <gmd:title>
+                        <gmx:Anchor xlink:href="http://data.europa.eu/bna/asd487ae75">High-value dataset categories</gmx:Anchor>
+                    </gmd:title>
+                    <gmd:date>
+                        <gmd:CI_Date>
+                            <gmd:date>
+                                <gco:Date>2023-09-05</gco:Date>
+                            </gmd:date>
+                            <gmd:dateType>
+                                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                            </gmd:dateType>
+                        </gmd:CI_Date>
+                    </gmd:date>
+                </gmd:CI_Citation>
+            </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+    </gmd:descriptiveKeywords>
+</gmd:MD_Metadata>
+```
+
+see https://dataeuropa.gitlab.io/data-provider-manual/hvd/annotation_in_geometadata
+'''
+
+from lxml import etree
+
+NS = {
+    "gmd": "http://www.isotc211.org/2005/gmd",
+    "gmx": "http://www.isotc211.org/2005/gmx",
+    "xlink": "http://www.w3.org/1999/xlink",
+}
+
+HVD_PREFIX = "http://data.europa.eu/bna/"
+HVD_THESAURUS_URI = f"{HVD_PREFIX}asd487ae75"
+
+# pattern for finding the correct gmd:descriptiveKeywords element
+# and extracting the keyword anchors from it
+HVD_PATTERN = f"""
+//gmd:descriptiveKeywords[
+  gmd:MD_Keywords
+    /gmd:thesaurusName
+    /gmd:CI_Citation
+    /gmd:title
+    /gmx:Anchor[@xlink:href="{HVD_THESAURUS_URI}"]
+]
+/gmd:MD_Keywords
+/gmd:keyword
+/gmx:Anchor[@xlink:href]
+"""
+
+def extract_hvd_categories(tree: etree) -> list:
+    """Extract a list of HVD categories from an ISO 19139
+    geospatial metadata XML document.
+
+    Args:
+        tree (etree): the XML document
+
+    Returns:
+        list: A list of dicts with 'uri' and 'label' keys
+    """
+
+    anchors = tree.xpath(HVD_PATTERN, namespaces=NS)
+    results = []
+
+    for anchor in anchors:
+        uri = anchor.get("{http://www.w3.org/1999/xlink}href")
+        label = anchor.text.strip() if anchor.text else None
+        if uri.startswith("http://data.europa.eu/bna/"):
+            results.append({"uri": uri, "label": label})
+    
+    return results
+

--- a/ckanext/fisbroker/plugin.py
+++ b/ckanext/fisbroker/plugin.py
@@ -39,7 +39,7 @@ class FisbrokerPlugin(plugins.SingletonPlugin):
         toolkit.add_public_directory(config, 'public')
         toolkit.add_resource('fanstatic', 'fisbroker')
         config['ckan.spatial.validator.profiles'] = 'always-valid'
-
+        config['ckanext.geoharvester.datasetschema'] = 'berlin_dataset_schema'
     # -------------------------------------------------------------------
     # Implementation ITemplateHelpers
     # -------------------------------------------------------------------

--- a/ckanext/fisbroker/tests/test_cli.py
+++ b/ckanext/fisbroker/tests/test_cli.py
@@ -21,6 +21,15 @@ from ckanext.fisbroker.tests import FisbrokerTestBase, base_context, FISBROKER_H
 
 LOG = logging.getLogger(__name__)
 
+@pytest.fixture(autouse=True)
+def disable_logging():
+    '''
+    For some reason there is CKAN log output (warning messages) that ends up in
+    the cli's result.stdout, making the following json.loads(result.stdout) fail.
+    This fixture supresses all logging while running these unit tests.
+    '''
+    logging.disable(logging.CRITICAL)
+
 @pytest.mark.ckan_config('ckan.plugins', f"{FISBROKER_PLUGIN} {HARVESTER_ID} harvest dummyharvest")
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
 class TestCli(FisbrokerTestBase):

--- a/ckanext/fisbroker/tests/test_harvester.py
+++ b/ckanext/fisbroker/tests/test_harvester.py
@@ -69,6 +69,7 @@ class TestTransformationHelpers(FisbrokerTestBase):
         xml_string = self._open_xml_fixture(dataset_name)
         iso_document = ISODocument(xml_string)
         iso_values = iso_document.read_values()
+        xml_tree = iso_document.xml_tree
         base_harvester = SpatialHarvester()
         source = self._create_source()
         obj = HarvestObject(
@@ -79,7 +80,8 @@ class TestTransformationHelpers(FisbrokerTestBase):
 
         data_dict = {
             'package_dict': package_dict ,
-            'iso_values': iso_values
+            'iso_values': iso_values,
+            'xml_tree': xml_tree
         }
         return data_dict
 

--- a/ckanext/fisbroker/tests/xml/wfs-open-data.xml
+++ b/ckanext/fisbroker/tests/xml/wfs-open-data.xml
@@ -1,4 +1,8 @@
-<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+<gmd:MD_Metadata
+  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
   <gmd:fileIdentifier>
     <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">65715c6e-bbaf-3def-982b-3b5156272da7</gco:CharacterString>
   </gmd:fileIdentifier>
@@ -256,6 +260,30 @@
                   </gmd:date>
                   <gmd:dateType>
                     <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gmx:Anchor xlink:href="http://data.europa.eu/bna/c_dd313021">Earth observation and environment</gmx:Anchor>
+          </gmd:keyword>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gmx:Anchor xlink:href="http://data.europa.eu/bna/asd487ae75">High-value dataset categories</gmx:Anchor>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2023-09-05</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                   </gmd:dateType>
                 </gmd:CI_Date>
               </gmd:date>


### PR DESCRIPTION
* Add a new CLI-command `get_record` to pull data from the CSW for a given guid. Data can be pulled in XML (as from the CSW), intermediate ISO format or final CKAN package dict (as the harvester would create it). Can be used to check the transformation without actually generating a new dataset.
* Extract HVD categories from the correct keywords element of the CSW record.
* Fix a problem running the unit tests locally, where CKAN log messages were polluting STDOUT, preventing it to be parsed as JSON.